### PR TITLE
Strip comment from nextValue to fix custom unmarshalers

### DIFF
--- a/encoding/json5/decode.go
+++ b/encoding/json5/decode.go
@@ -231,7 +231,6 @@ func (d *decodeState) scanInlineComment() int {
 		c := int(d.data[d.off])
 		d.off++
 		newOp = d.scan.step(&d.scan, c)
-		fmt.Println("c = ", string(c))
 		if newOp != scanSkipInComment {
 			break
 		}

--- a/encoding/json5/decode_test.go
+++ b/encoding/json5/decode_test.go
@@ -7,6 +7,7 @@ package json5
 import (
 	"bytes"
 	"encoding"
+	"encoding/json"
 	"fmt"
 	"image"
 	"reflect"
@@ -1352,5 +1353,38 @@ func TestInvalidUnmarshal(t *testing.T) {
 		if got := err.Error(); got != tt.want {
 			t.Errorf("Unmarshal = %q; want %q", got, tt.want)
 		}
+	}
+}
+
+type objectDecoder struct {
+	A int
+}
+
+func (o *objectDecoder) UnmarshalJSON(data []byte) error {
+	var v struct {
+		A int `json:"a"`
+	}
+
+	err := json.Unmarshal(data, &v)
+	if err != nil {
+		return err
+	}
+
+	o.A = v.A
+
+	return nil
+}
+
+func TestDecoder_Decode_Unmarshaler(t *testing.T) {
+	j5 := `{
+	// A.
+	"a": 123
+}`
+	var v objectDecoder
+
+	err := NewDecoder(bytes.NewBufferString(j5)).Decode(&v)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
 	}
 }

--- a/encoding/json5/scanner.go
+++ b/encoding/json5/scanner.go
@@ -38,17 +38,26 @@ func nextValue(data []byte, scan *scanner) (value, rest []byte, err error) {
 	scan.reset()
 	for i, c := range data {
 		v := scan.step(scan, int(c))
+		if v == scanSkipInComment {
+			value = append(value, ' ')
+		} else {
+			value = append(value, data[i])
+		}
+
 		if v >= scanEnd {
 			switch v {
 			case scanError:
 				return nil, nil, scan.err
 			case scanEnd:
-				return data[0:i], data[i:], nil
+				return value[0 : len(value)-1], data[i:], nil
 			}
 		}
 	}
 	if scan.eof() == scanError {
 		return nil, nil, scan.err
+	}
+	if len(value) > 0 {
+		return value, nil, nil
 	}
 	return data, nil, nil
 }
@@ -711,7 +720,7 @@ func quoteChar(c int) string {
 	}
 
 	// use quoted string with different quotation marks
-	s := strconv.Quote(string(c))
+	s := strconv.Quote(string(rune(c)))
 	return "'" + s[1:len(s)-1] + "'"
 }
 

--- a/encoding/json5/scanner_test.go
+++ b/encoding/json5/scanner_test.go
@@ -186,7 +186,7 @@ func TestNextValueBig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("nextValue: %s", err)
 	}
-	if len(item) != len(jsonBig) || &item[0] != &jsonBig[0] {
+	if len(item) != len(jsonBig) || item[0] != jsonBig[0] {
 		t.Errorf("invalid item: %d %d", len(item), len(jsonBig))
 	}
 	if len(rest) != 0 {


### PR DESCRIPTION
This PR fixes an issue that JSON5 value can not be unmarshaled into an instance of type that implements `json.Unmarshaler`.

Such implementations are not aware of JSON5 extensions and fail when see a comment.

This PR changes `nextValue` scanner to use separate buffer with comments replaced by spaces. It hurts performance, but improves correctness.