### PR TITLE
Fix LICENSE.md for pkg.go.dev

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,7 @@
 BSD License
-====================
 
-_Copyright © `2019`, `Yosuke Furukawa`_  
-_All rights reserved._
+Copyright © 2019, Yosuke Furukawa
+All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
This should fix viewing docs through pkg.go.dev
https://pkg.go.dev/github.com/yosuke-furukawa/json5@v0.1.1/encoding/json5