### PR TITLE
Fix parse error when Json objects or arrays ends with //.

### DIFF
--- a/encoding/json5/scanner.go
+++ b/encoding/json5/scanner.go
@@ -291,6 +291,12 @@ func stateBeginValueFromComment(s *scanner, c int) int {
 	case '/': // beginning of comment
 		s.step = stateInlineComment
 		return scanSkipInComment
+	case '}':
+		s.step = stateBeginStringOrEmpty
+		return stateBeginStringOrEmpty(s, c)
+	case ']':
+		s.step = stateBeginValueOrEmpty
+		return stateBeginValueOrEmpty(s, c)
 	}
 	if '1' <= c && c <= '9' { // beginning of 1234.5
 		s.step = state1


### PR DESCRIPTION
Folloing JSON is not accepted because stateBeginValueFromComment doesn't handle ']' nor '}'. 

{
  "arr": [
    10,
    // comment
  ],
  "n": 1,
  // Z
}

This change fixes issue #14